### PR TITLE
fix: Example 페이지를 열었을 때 id 초기값 추가

### DIFF
--- a/src/components/Example/Example.jsx
+++ b/src/components/Example/Example.jsx
@@ -34,7 +34,7 @@ const Example = () => {
     ];
 
     const location = useLocation();
-    const [id, setId] = useState(location.pathname.split('/')[2]);
+    const [id, setId] = useState(location.pathname.split('/')[2] || 'getStarted');
     console.log('Example ', id);
 
     return (


### PR DESCRIPTION
 - Example 의 pathname 이 undefined 일 때 처리할 수 있도록 초기값 추가